### PR TITLE
tweaking numeric_compare_function in stats_array_data_compare

### DIFF
--- a/php_stats.c
+++ b/php_stats.c
@@ -163,7 +163,7 @@ static int stats_array_data_compare(const void *a, const void *b TSRMLS_DC)
 {
 	Bucket *f;
 	Bucket *s;
-	zval result;
+	int result;
 	zval first;
 	zval second;
 
@@ -173,25 +173,11 @@ static int stats_array_data_compare(const void *a, const void *b TSRMLS_DC)
 	first = f->val;
 	second = s->val;
 
-	if (numeric_compare_function(&result, &first, &second TSRMLS_CC) == FAILURE) {
-		return 0;
-	}
+	result = numeric_compare_function(&first, &second TSRMLS_CC);
 
-	if (Z_TYPE(result) == IS_DOUBLE) {
-		if (Z_DVAL(result) < 0) {
-			return -1;
-		} else if (Z_DVAL(result) > 0) {
-			return 1;
-		} else {
-			return 0;
-		}
-	}
-
-	convert_to_long(&result);
-
-	if (Z_LVAL(result) < 0) {
+	if (result < 0) {
 		return -1;
-	} else if (Z_LVAL(result) > 0) {
+	} else if (result > 0) {
 		return 1;
 	}
 


### PR DESCRIPTION
numeric_compare_function still compares two zvals but doesn't take a third
param anymore. Now it returns an int instead. Cleaned up code a bit around
now as well, since we don't have to worry so much about return types as
numeric_compare_function returns an int instead of a zval