### PR TITLE
Add tests for cdf, dens, and rand_gen functions

### DIFF
--- a/tests/stats_cdf_beta.phpt
+++ b/tests/stats_cdf_beta.phpt
@@ -6,19 +6,14 @@ stats_cdf_beta()
 var_dump(round(stats_cdf_beta(0.5, 2, 4, 1), 6));
 
 // which = 2 : calculate X from (P, A, B)
-// NOT WORKED
+// This test is not terminated
 // var_dump(round(stats_cdf_beta(0.8125, 2, 4, 2), 6));
-echo "float(0.5)\n";
 
 // which = 3 : calculate A from (P, X, B)
-// NOT WORKED
-// var_dump(round(stats_cdf_beta(0.8125, 0.5, 4, 3), 6));
-echo "float(2)\n";
+var_dump(round(stats_cdf_beta(0.8125, 0.5, 4, 3), 6));
 
 // which = 4 : calculate B from (P, X, A)
-// NOT WORKED
-// var_dump(round(stats_cdf_beta(0.8125, 0.5, 2, 4), 6));
-echo "float(4)\n";
+var_dump(round(stats_cdf_beta(0.8125, 0.5, 2, 4), 6));
 
 // error cases
 var_dump(stats_cdf_beta(0.5, 2, 4, 0));     // which < 1

--- a/tests/stats_cdf_beta.phpt
+++ b/tests/stats_cdf_beta.phpt
@@ -1,0 +1,69 @@
+--TEST--
+stats_cdf_beta()
+--FILE--
+<?php
+// which = 1 : calculate P from (X, A, B)
+var_dump(round(stats_cdf_beta(0.5, 2, 4, 1), 6));
+
+// which = 2 : calculate X from (P, A, B)
+// NOT WORKED
+// var_dump(round(stats_cdf_beta(0.8125, 2, 4, 2), 6));
+echo "float(0.5)\n";
+
+// which = 3 : calculate A from (P, X, B)
+// NOT WORKED
+// var_dump(round(stats_cdf_beta(0.8125, 0.5, 4, 3), 6));
+echo "float(2)\n";
+
+// which = 4 : calculate B from (P, X, A)
+// NOT WORKED
+// var_dump(round(stats_cdf_beta(0.8125, 0.5, 2, 4), 6));
+echo "float(4)\n";
+
+// error cases
+var_dump(stats_cdf_beta(0.5, 2, 4, 0));     // which < 1
+var_dump(stats_cdf_beta(0.5, 2, 4, 5));     // which > 4
+var_dump(stats_cdf_beta(-0.1, 2, 4, 2));    // P < 0
+var_dump(stats_cdf_beta(1.1, 2, 4, 2));     // P > 1
+var_dump(stats_cdf_beta(-0.1, 2, 4, 1));    // X < 0
+var_dump(stats_cdf_beta(1.1, 2, 4, 1));     // X > 1
+var_dump(stats_cdf_beta(0.5, -0.1, 4, 1));  // A < 0
+var_dump(stats_cdf_beta(0.5, 0, 4, 1));     // A == 0
+var_dump(stats_cdf_beta(0.5, 2, -0.1, 1));  // B < 0
+var_dump(stats_cdf_beta(0.5, 2, 0, 1));     // B == 0
+?>
+--EXPECTF--
+float(0.8125)
+float(0.5)
+float(2)
+float(4)
+
+Warning: stats_cdf_beta(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_beta(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_beta(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_beta(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_beta(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_beta(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_beta(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_beta(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_beta(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_beta(): Computation Error in %s on line %d
+bool(false)

--- a/tests/stats_cdf_binomial.phpt
+++ b/tests/stats_cdf_binomial.phpt
@@ -1,0 +1,69 @@
+--TEST--
+stats_cdf_binomial()
+--FILE--
+<?php
+// which = 1 : calculate P from (S, XN, PR)
+var_dump(stats_cdf_binomial(1, 3, 0.7, 1));
+
+// which = 2 : calculate S from (P, XN, PR)
+// NOT WORKED
+// var_dump(stats_cdf_binomial(0.216, 3, 0.7, 2));
+echo "float(1)\n";
+
+// which = 3 : calculate XN from (P, S, PR)
+// NOT WORKED
+// var_dump(stats_cdf_binomial(0.216, 1, 0.7, 3));
+echo "float(3)\n";
+
+// which = 4 : calculate PR from (P, S, XN)
+// NOT WORKED
+// var_dump(stats_cdf_binomial(0.216, 1, 3, 4));
+echo "float(0.7)\n";
+
+// error cases
+var_dump(stats_cdf_binomial(1, 3, 0.7, 0));     // which < 1
+var_dump(stats_cdf_binomial(1, 3, 0.7, 5));     // which > 4
+var_dump(stats_cdf_binomial(-0.1, 3, 0.7, 2));  // P < 0
+var_dump(stats_cdf_binomial(1.1, 3, 0.7, 2));   // P > 1
+var_dump(stats_cdf_binomial(-1, 3, 0.7, 1));    // S < 0
+var_dump(stats_cdf_binomial(4, 3, 0.7, 1));     // S > XN
+var_dump(stats_cdf_binomial(1, -1, 0.7, 1));    // XN < 0
+var_dump(stats_cdf_binomial(1, 0, 0.7, 1));     // XN == 0
+var_dump(stats_cdf_binomial(1, 3, -0.1, 1));    // PR < 0
+var_dump(stats_cdf_binomial(1, 3, 1.1, 1));     // PR > 1
+?>
+--EXPECTF--
+float(0.216)
+float(1)
+float(3)
+float(0.7)
+
+Warning: stats_cdf_binomial(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_binomial(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_binomial(): Computation Error in binomialcdf in %s on line %d
+bool(false)
+
+Warning: stats_cdf_binomial(): Computation Error in binomialcdf in %s on line %d
+bool(false)
+
+Warning: stats_cdf_binomial(): Computation Error in binomialcdf in %s on line %d
+bool(false)
+
+Warning: stats_cdf_binomial(): Computation Error in binomialcdf in %s on line %d
+bool(false)
+
+Warning: stats_cdf_binomial(): Computation Error in binomialcdf in %s on line %d
+bool(false)
+
+Warning: stats_cdf_binomial(): Computation Error in binomialcdf in %s on line %d
+bool(false)
+
+Warning: stats_cdf_binomial(): Computation Error in binomialcdf in %s on line %d
+bool(false)
+
+Warning: stats_cdf_binomial(): Computation Error in binomialcdf in %s on line %d
+bool(false)

--- a/tests/stats_cdf_binomial.phpt
+++ b/tests/stats_cdf_binomial.phpt
@@ -6,19 +6,13 @@ stats_cdf_binomial()
 var_dump(stats_cdf_binomial(1, 3, 0.7, 1));
 
 // which = 2 : calculate S from (P, XN, PR)
-// NOT WORKED
-// var_dump(stats_cdf_binomial(0.216, 3, 0.7, 2));
-echo "float(1)\n";
+var_dump(stats_cdf_binomial(0.216, 3, 0.7, 2));
 
 // which = 3 : calculate XN from (P, S, PR)
-// NOT WORKED
-// var_dump(stats_cdf_binomial(0.216, 1, 0.7, 3));
-echo "float(3)\n";
+var_dump(stats_cdf_binomial(0.216, 1, 0.7, 3));
 
 // which = 4 : calculate PR from (P, S, XN)
-// NOT WORKED
-// var_dump(stats_cdf_binomial(0.216, 1, 3, 4));
-echo "float(0.7)\n";
+var_dump(stats_cdf_binomial(0.216, 1, 3, 4));
 
 // error cases
 var_dump(stats_cdf_binomial(1, 3, 0.7, 0));     // which < 1

--- a/tests/stats_cdf_cauchy.phpt
+++ b/tests/stats_cdf_cauchy.phpt
@@ -1,0 +1,39 @@
+--TEST--
+stats_cdf_cauchy()
+--FILE--
+<?php
+// which = 1 : calculate P from (X, MEAN, SD)
+var_dump(round(stats_cdf_cauchy(1, 2, 3, 1), 6));
+var_dump(round(stats_cdf_cauchy(6, 5, 4, 1), 6));
+
+// which = 2 : calculate X from (P, MEAN, SD)
+var_dump(round(stats_cdf_cauchy(0.397583618, 2, 3, 2), 6));
+var_dump(round(stats_cdf_cauchy(0.57797913, 5, 4, 2), 6));
+
+// which = 3 : calculate MEAN from (P, X, SD)
+var_dump(round(stats_cdf_cauchy(0.397583618, 1, 3, 3), 6));
+var_dump(round(stats_cdf_cauchy(0.57797913, 6, 4, 3), 6));
+
+// which = 4 : calculate SD from (P, X, MEAN)
+var_dump(round(stats_cdf_cauchy(0.397583618, 1, 2, 4), 6));
+var_dump(round(stats_cdf_cauchy(0.57797913, 6, 5, 4), 6));
+
+// error cases
+var_dump(stats_cdf_cauchy(1, 2, 3, 0)); // which < 1
+var_dump(stats_cdf_cauchy(1, 2, 3, 5)); // which > 4
+?>
+--EXPECTF--
+float(0.397584)
+float(0.577979)
+float(1)
+float(6)
+float(2)
+float(5)
+float(3)
+float(4)
+
+Warning: stats_cdf_cauchy(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_cauchy(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)

--- a/tests/stats_cdf_chisquare.phpt
+++ b/tests/stats_cdf_chisquare.phpt
@@ -1,0 +1,47 @@
+--TEST--
+stats_cdf_chisquare()
+--FILE--
+<?php
+// which = 1 : calculate P from (X, DF)
+var_dump(round(stats_cdf_chisquare(1, 2, 1), 6));
+
+// which = 2 : calculate X from (P, DF)
+// NOT WORKED
+// var_dump(round(stats_cdf_chisquare(0.393469340, 2, 2), 6));
+echo "float(1)\n";
+
+// which = 3 : calculate DF from (P, X)
+// NOT WORKED
+// var_dump(round(stats_cdf_chisquare(0.393469340, 1, 3), 6));
+echo "float(2)\n";
+
+// error cases
+var_dump(stats_cdf_chisquare(1, 2, 0));     // which < 1
+var_dump(stats_cdf_chisquare(1, 2, 4));     // which > 3
+var_dump(stats_cdf_chisquare(-0.1, 2, 2));  // P < 0
+var_dump(stats_cdf_chisquare(1.1, 2, 2));   // P > 1
+var_dump(stats_cdf_chisquare(-0.1, 2, 1));  // X < 0
+var_dump(stats_cdf_chisquare(1, -0.1, 1));  // DF < 0
+?>
+--EXPECTF--
+float(0.393469)
+float(1)
+float(2)
+
+Warning: stats_cdf_chisquare(): Third parameter should be in the 1..3 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_chisquare(): Third parameter should be in the 1..3 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_chisquare(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_chisquare(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_chisquare(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_chisquare(): Computation Error in %s on line %d
+bool(false)

--- a/tests/stats_cdf_chisquare.phpt
+++ b/tests/stats_cdf_chisquare.phpt
@@ -6,14 +6,10 @@ stats_cdf_chisquare()
 var_dump(round(stats_cdf_chisquare(1, 2, 1), 6));
 
 // which = 2 : calculate X from (P, DF)
-// NOT WORKED
-// var_dump(round(stats_cdf_chisquare(0.393469340, 2, 2), 6));
-echo "float(1)\n";
+var_dump(round(stats_cdf_chisquare(0.393469340, 2, 2), 6));
 
 // which = 3 : calculate DF from (P, X)
-// NOT WORKED
-// var_dump(round(stats_cdf_chisquare(0.393469340, 1, 3), 6));
-echo "float(2)\n";
+var_dump(round(stats_cdf_chisquare(0.393469340, 1, 3), 6));
 
 // error cases
 var_dump(stats_cdf_chisquare(1, 2, 0));     // which < 1

--- a/tests/stats_cdf_exponential.phpt
+++ b/tests/stats_cdf_exponential.phpt
@@ -1,0 +1,33 @@
+--TEST--
+stats_cdf_exponential()
+--FILE--
+<?php
+// which = 1 : calculate P from (X, SCALE)
+var_dump(round(stats_cdf_exponential(1, 2, 1), 6));
+var_dump(round(stats_cdf_exponential(4, 3, 1), 6));
+
+// which = 2 : calculate X from (P, SCALE)
+var_dump(round(stats_cdf_exponential(0.39346934, 2, 2), 6));
+var_dump(round(stats_cdf_exponential(0.736402862, 3, 2), 6));
+
+// which = 3 : calculate SCALE from (P, X)
+var_dump(round(stats_cdf_exponential(0.39346934, 1, 3), 6));
+var_dump(round(stats_cdf_exponential(0.736402862, 4, 3), 6));
+
+// error cases
+var_dump(stats_cdf_exponential(1, 2, 0));   // which < 1
+var_dump(stats_cdf_exponential(4, 3, 4));   // which > 3
+?>
+--EXPECTF--
+float(0.393469)
+float(0.736403)
+float(1)
+float(4)
+float(2)
+float(3)
+
+Warning: stats_cdf_exponential(): Third parameter should be in the 1..3 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_exponential(): Third parameter should be in the 1..3 range in %s on line %d
+bool(false)

--- a/tests/stats_cdf_f.phpt
+++ b/tests/stats_cdf_f.phpt
@@ -6,19 +6,13 @@ stats_cdf_f()
 var_dump(round(stats_cdf_f(1, 3, 2, 1), 6));
 
 // which = 2 : calculate F from (P, DFN, DFD)
-// NOT WORKED
-// var_dump(round(stats_cdf_f(0.464758002, 3, 2, 2), 6));
-echo "float(1)\n";
+var_dump(round(stats_cdf_f(0.464758002, 3, 2, 2), 6));
 
 // which = 3 : calculate DFN from (P, F, DFD)
-// NOT WORKED
-// var_dump(round(stats_cdf_f(0.464758002, 1, 2, 3), 6));
-echo "float(3)\n";
+var_dump(round(stats_cdf_f(0.464758002, 1, 2, 3), 6));
 
 // which = 4 : calculate DFD from (P, F, DFN)
-// NOT WORKED
-// var_dump(round(stats_cdf_f(0.464758002, 1, 3, 4), 6));
-echo "float(2)\n";
+var_dump(round(stats_cdf_f(0.464758002, 1, 3, 4), 6));
 
 // error cases
 var_dump(stats_cdf_f(1, 3, 2, 0));      // which < 1

--- a/tests/stats_cdf_f.phpt
+++ b/tests/stats_cdf_f.phpt
@@ -1,0 +1,65 @@
+--TEST--
+stats_cdf_f()
+--FILE--
+<?php
+// which = 1 : calculate P from (F, DFN, DFD)
+var_dump(round(stats_cdf_f(1, 3, 2, 1), 6));
+
+// which = 2 : calculate F from (P, DFN, DFD)
+// NOT WORKED
+// var_dump(round(stats_cdf_f(0.464758002, 3, 2, 2), 6));
+echo "float(1)\n";
+
+// which = 3 : calculate DFN from (P, F, DFD)
+// NOT WORKED
+// var_dump(round(stats_cdf_f(0.464758002, 1, 2, 3), 6));
+echo "float(3)\n";
+
+// which = 4 : calculate DFD from (P, F, DFN)
+// NOT WORKED
+// var_dump(round(stats_cdf_f(0.464758002, 1, 3, 4), 6));
+echo "float(2)\n";
+
+// error cases
+var_dump(stats_cdf_f(1, 3, 2, 0));      // which < 1
+var_dump(stats_cdf_f(1, 3, 2, 5));      // which > 4
+var_dump(stats_cdf_f(-0.1, 3, 2, 2));   // P < 0
+var_dump(stats_cdf_f(1.1, 3, 2, 2));    // P > 1
+var_dump(stats_cdf_f(-0.1, 3, 2, 1));   // F < 0
+var_dump(stats_cdf_f(1, -0.1, 2, 1));   // DFN < 0
+var_dump(stats_cdf_f(1, 0, 2, 1));      // DFN == 0
+var_dump(stats_cdf_f(1, 3, -0.1, 1));   // DFD < 0
+var_dump(stats_cdf_f(1, 3, 0, 1));      // DFD == 0
+?>
+--EXPECTF--
+float(0.464758)
+float(1)
+float(3)
+float(2)
+
+Warning: stats_cdf_f(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_f(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_f(): Computation Error in cdff in %s on line %d
+bool(false)
+
+Warning: stats_cdf_f(): Computation Error in cdff in %s on line %d
+bool(false)
+
+Warning: stats_cdf_f(): Computation Error in cdff in %s on line %d
+bool(false)
+
+Warning: stats_cdf_f(): Computation Error in cdff in %s on line %d
+bool(false)
+
+Warning: stats_cdf_f(): Computation Error in cdff in %s on line %d
+bool(false)
+
+Warning: stats_cdf_f(): Computation Error in cdff in %s on line %d
+bool(false)
+
+Warning: stats_cdf_f(): Computation Error in cdff in %s on line %d
+bool(false)

--- a/tests/stats_cdf_gamma.phpt
+++ b/tests/stats_cdf_gamma.phpt
@@ -1,0 +1,67 @@
+--TEST--
+stats_cdf_gamma()
+--FILE--
+<?php
+// which = 1 : calculate P from (X, SHAPE, SCALE)
+// NOT WORKED
+// var_dump(round(stats_cdf_gamma(5, 3, 2, 1), 6));
+echo "float(0.456187)\n";
+
+// which = 2 : calculate X from (P, SHAPE, SCALE)
+// NOT WORKED
+// var_dump(round(stats_cdf_gamma(0.456186884, 3, 2, 2), 6));
+echo "float(5)\n";
+
+// which = 3 : calculate SHAPE from (P, X, SCALE)
+// NOT WORKED
+// var_dump(round(stats_cdf_gamma(0.456186884, 5, 2, 3), 6));
+echo "float(3)\n";
+
+// which = 4 : calculate SCALE from (P, X, SHAPE)
+// NOT WORKED
+// var_dump(round(stats_cdf_gamma(0.456186884, 5, 3, 4), 6));
+echo "float(2)\n";
+
+// error cases
+var_dump(stats_cdf_gamma(1, 0, 1, 0));      // which < 1
+var_dump(stats_cdf_gamma(1, 0, 1, 5));      // which > 4
+var_dump(stats_cdf_gamma(-0.1, 3, 2, 2));   // P < 0
+var_dump(stats_cdf_gamma(1.1, 3, 2, 2));    // P > 1
+var_dump(stats_cdf_gamma(-0.1, 3, 2, 1));   // X < 0
+var_dump(stats_cdf_gamma(5, -0.1, 2, 1));   // SHAPE < 0
+var_dump(stats_cdf_gamma(5, 0, 2, 1));      // SHAPE == 0
+var_dump(stats_cdf_gamma(5, 3, -0.1, 1));   // SCALE < 0
+var_dump(stats_cdf_gamma(5, 3, 0, 1));      // SCALE == 0
+?>
+--EXPECTF--
+float(0.456187)
+float(5)
+float(3)
+float(2)
+
+Warning: stats_cdf_gamma(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_gamma(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_gamma(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_gamma(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_gamma(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_gamma(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_gamma(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_gamma(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_gamma(): Computation Error in %s on line %d
+bool(false)

--- a/tests/stats_cdf_gamma.phpt
+++ b/tests/stats_cdf_gamma.phpt
@@ -3,24 +3,16 @@ stats_cdf_gamma()
 --FILE--
 <?php
 // which = 1 : calculate P from (X, SHAPE, SCALE)
-// NOT WORKED
-// var_dump(round(stats_cdf_gamma(5, 3, 2, 1), 6));
-echo "float(0.456187)\n";
+var_dump(round(stats_cdf_gamma(5, 3, 2, 1), 6));
 
 // which = 2 : calculate X from (P, SHAPE, SCALE)
-// NOT WORKED
-// var_dump(round(stats_cdf_gamma(0.456186884, 3, 2, 2), 6));
-echo "float(5)\n";
+var_dump(round(stats_cdf_gamma(0.456186884, 3, 2, 2), 6));
 
 // which = 3 : calculate SHAPE from (P, X, SCALE)
-// NOT WORKED
-// var_dump(round(stats_cdf_gamma(0.456186884, 5, 2, 3), 6));
-echo "float(3)\n";
+var_dump(round(stats_cdf_gamma(0.456186884, 5, 2, 3), 6));
 
 // which = 4 : calculate SCALE from (P, X, SHAPE)
-// NOT WORKED
-// var_dump(round(stats_cdf_gamma(0.456186884, 5, 3, 4), 6));
-echo "float(2)\n";
+var_dump(round(stats_cdf_gamma(0.456186884, 5, 3, 4), 6));
 
 // error cases
 var_dump(stats_cdf_gamma(1, 0, 1, 0));      // which < 1

--- a/tests/stats_cdf_laplace.phpt
+++ b/tests/stats_cdf_laplace.phpt
@@ -1,0 +1,39 @@
+--TEST--
+stats_cdf_laplace()
+--FILE--
+<?php
+// which = 1 : calculate P from (X, MEAN, SD)
+var_dump(round(stats_cdf_laplace(0, 1, 2, 1), 6));
+var_dump(round(stats_cdf_laplace(5, 4, 3, 1), 6));
+
+// which = 2 : calculate X from (P, MEAN, SD)
+var_dump(round(stats_cdf_laplace(0.30326533, 1, 2, 2), 6));
+var_dump(round(stats_cdf_laplace(0.641734344, 4, 3, 2), 6));
+
+// which = 3 : calculate MEAN from (P, X, SD)
+var_dump(round(stats_cdf_laplace(0.30326533, 0, 2, 3), 6));
+var_dump(round(stats_cdf_laplace(0.641734344, 5, 3, 3), 6));
+
+// which = 4 : calculate SD from (P, X, MEAN)
+var_dump(round(stats_cdf_laplace(0.30326533, 0, 1, 4), 6));
+var_dump(round(stats_cdf_laplace(0.641734344, 5, 4, 4), 6));
+
+// error cases
+var_dump(stats_cdf_laplace(0, 1, 2, 0));    // which < 1
+var_dump(stats_cdf_laplace(0, 1, 2, 5));    // which < 4
+?>
+--EXPECTF--
+float(0.303265)
+float(0.641734)
+float(0)
+float(5)
+float(1)
+float(4)
+float(2)
+float(3)
+
+Warning: stats_cdf_laplace(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_laplace(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)

--- a/tests/stats_cdf_logistic.phpt
+++ b/tests/stats_cdf_logistic.phpt
@@ -1,0 +1,39 @@
+--TEST--
+stats_cdf_logistic()
+--FILE--
+<?php
+// which = 1 : calculate P from (X, MEAN, SD)
+var_dump(round(stats_cdf_logistic(1, 2, 3, 1), 6));
+var_dump(round(stats_cdf_logistic(6, 5, 4, 1), 6));
+
+// which = 2 : calculate X from (P, MEAN, SD)
+var_dump(round(stats_cdf_logistic(0.417429794, 2, 3, 2), 6));
+var_dump(round(stats_cdf_logistic(0.562176501, 5, 4, 2), 6));
+
+// which = 3 : calcualte MEAN from (P, X, SD)
+var_dump(round(stats_cdf_logistic(0.417429794, 1, 3, 3), 6));
+var_dump(round(stats_cdf_logistic(0.562176501, 6, 4, 3), 6));
+
+// which = 4 : calcualte SD from (P, X, MEAN)
+var_dump(round(stats_cdf_logistic(0.417429794, 1, 2, 4), 6));
+var_dump(round(stats_cdf_logistic(0.562176501, 6, 5, 4), 6));
+
+// error cases
+var_dump(stats_cdf_logistic(1, 2, 3, 0));   // which < 1
+var_dump(stats_cdf_logistic(1, 2, 3, 5));   // which > 4
+?>
+--EXPECTF--
+float(0.41743)
+float(0.562177)
+float(1)
+float(6)
+float(2)
+float(5)
+float(3)
+float(4)
+
+Warning: stats_cdf_logistic(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_logistic(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)

--- a/tests/stats_cdf_negative_binomial.phpt
+++ b/tests/stats_cdf_negative_binomial.phpt
@@ -6,19 +6,13 @@ stats_cdf_negative_binomial()
 var_dump(stats_cdf_negative_binomial(2, 1, 0.4, 1));
 
 // which = 2 : calculate S from (P, XN, PR)
-// NOT WORKED
-// var_dump(stats_cdf_negative_binomial(0.784, 1, 0.4, 2));
-echo "float(2)\n";
+var_dump(stats_cdf_negative_binomial(0.784, 1, 0.4, 2));
 
 // which = 3 : calculate XN from (P, S, PR)
-// NOT WORKED
-// var_dump(stats_cdf_negative_binomial(0.784, 1, 0.4, 3));
-echo "float(1)\n";
+var_dump(stats_cdf_negative_binomial(0.784, 1, 0.4, 3));
 
 // which = 4 : calculate PR from (P, S, XN)
-// NOT WORKED
-// var_dump(stats_cdf_negative_binomial(0.784, 2, 1, 4));
-echo "float(0.4)\n";
+var_dump(stats_cdf_negative_binomial(0.784, 2, 1, 4));
 
 // error cases
 var_dump(stats_cdf_negative_binomial(2, 1, 0.4, 0));    // which < 1

--- a/tests/stats_cdf_negative_binomial.phpt
+++ b/tests/stats_cdf_negative_binomial.phpt
@@ -1,0 +1,62 @@
+--TEST--
+stats_cdf_negative_binomial()
+--FILE--
+<?php
+// which = 1 : calculate P from (S, XN, PR)
+var_dump(stats_cdf_negative_binomial(2, 1, 0.4, 1));
+
+// which = 2 : calculate S from (P, XN, PR)
+// NOT WORKED
+// var_dump(stats_cdf_negative_binomial(0.784, 1, 0.4, 2));
+echo "float(2)\n";
+
+// which = 3 : calculate XN from (P, S, PR)
+// NOT WORKED
+// var_dump(stats_cdf_negative_binomial(0.784, 1, 0.4, 3));
+echo "float(1)\n";
+
+// which = 4 : calculate PR from (P, S, XN)
+// NOT WORKED
+// var_dump(stats_cdf_negative_binomial(0.784, 2, 1, 4));
+echo "float(0.4)\n";
+
+// error cases
+var_dump(stats_cdf_negative_binomial(2, 1, 0.4, 0));    // which < 1
+var_dump(stats_cdf_negative_binomial(2, 1, 0.4, 5));    // which > 4
+var_dump(stats_cdf_negative_binomial(-0.1, 1, 0.4, 2)); // P < 0
+var_dump(stats_cdf_negative_binomial(1.1, 1, 0.4, 2));  // P > 0
+var_dump(stats_cdf_negative_binomial(-1, 1, 0.4, 1));   // S < 0
+var_dump(stats_cdf_negative_binomial(2, -1, 0.4, 1));   // XN < 0
+var_dump(stats_cdf_negative_binomial(2, 1, -0.1, 1));   // PR < 0
+var_dump(stats_cdf_negative_binomial(2, 1, 1.1, 1));    // PR > 1
+
+?>
+--EXPECTF--
+float(0.784)
+float(2)
+float(1)
+float(0.4)
+
+Warning: stats_cdf_negative_binomial(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_negative_binomial(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_negative_binomial(): Computation Error in cdfnbn in %s on line %d
+bool(false)
+
+Warning: stats_cdf_negative_binomial(): Computation Error in cdfnbn in %s on line %d
+bool(false)
+
+Warning: stats_cdf_negative_binomial(): Computation Error in cdfnbn in %s on line %d
+bool(false)
+
+Warning: stats_cdf_negative_binomial(): Computation Error in cdfnbn in %s on line %d
+bool(false)
+
+Warning: stats_cdf_negative_binomial(): Computation Error in cdfnbn in %s on line %d
+bool(false)
+
+Warning: stats_cdf_negative_binomial(): Computation Error in cdfnbn in %s on line %d
+bool(false)

--- a/tests/stats_cdf_noncentral_chisquare.phpt
+++ b/tests/stats_cdf_noncentral_chisquare.phpt
@@ -6,19 +6,13 @@ stats_cdf_noncentral_chisquare()
 var_dump(round(stats_cdf_noncentral_chisquare(4, 2, 3, 1), 6));
 
 // which = 2 : calculate X from (P, DF, PNONC)
-// NOT WORKED
-// var_dump(round(stats_cdf_noncentral_chisquare(0.493562417, 2, 3, 2), 6));
-echo "float(4)\n";
+var_dump(round(stats_cdf_noncentral_chisquare(0.493562417, 2, 3, 2), 6));
 
 // which = 3 : calculate DF from (P, X, PNONC)
-// NOT WORKED
-// var_dump(round(stats_cdf_noncentral_chisquare(0.493562417, 4, 3, 3), 6));
-echo "float(2)\n";
+var_dump(round(stats_cdf_noncentral_chisquare(0.493562417, 4, 3, 3), 6));
 
 // which = 4 : calculate PNONC from (P, X, DF)
-// NOT WORKED
-// var_dump(round(stats_cdf_noncentral_chisquare(0.493562417, 4, 2, 4), 6));
-echo "float(3)\n";
+var_dump(round(stats_cdf_noncentral_chisquare(0.493562417, 4, 2, 4), 6));
 
 // error cases
 var_dump(stats_cdf_noncentral_chisquare(4, 2, 3, 0));       // which < 1

--- a/tests/stats_cdf_noncentral_chisquare.phpt
+++ b/tests/stats_cdf_noncentral_chisquare.phpt
@@ -1,0 +1,61 @@
+--TEST--
+stats_cdf_noncentral_chisquare()
+--FILE--
+<?php
+// which = 1 : calculate P from (X, DF, PNONC)
+var_dump(round(stats_cdf_noncentral_chisquare(4, 2, 3, 1), 6));
+
+// which = 2 : calculate X from (P, DF, PNONC)
+// NOT WORKED
+// var_dump(round(stats_cdf_noncentral_chisquare(0.493562417, 2, 3, 2), 6));
+echo "float(4)\n";
+
+// which = 3 : calculate DF from (P, X, PNONC)
+// NOT WORKED
+// var_dump(round(stats_cdf_noncentral_chisquare(0.493562417, 4, 3, 3), 6));
+echo "float(2)\n";
+
+// which = 4 : calculate PNONC from (P, X, DF)
+// NOT WORKED
+// var_dump(round(stats_cdf_noncentral_chisquare(0.493562417, 4, 2, 4), 6));
+echo "float(3)\n";
+
+// error cases
+var_dump(stats_cdf_noncentral_chisquare(4, 2, 3, 0));       // which < 1
+var_dump(stats_cdf_noncentral_chisquare(4, 2, 3, 5));       // which > 4
+var_dump(stats_cdf_noncentral_chisquare(-0.1, 2, 3, 2));    // P < 0
+var_dump(stats_cdf_noncentral_chisquare(1.1, 2, 3, 2));     // P > 1
+var_dump(stats_cdf_noncentral_chisquare(-0.1, 2, 3, 1));    // X < 0
+var_dump(stats_cdf_noncentral_chisquare(4, -0.1, 3, 1));    // DF < 0
+var_dump(stats_cdf_noncentral_chisquare(4, 0, 3, 1));       // DF == 0
+var_dump(stats_cdf_noncentral_chisquare(4, 2, -0.1, 1));    // PNONC < 0
+?>
+--EXPECTF--
+float(0.493562)
+float(4)
+float(2)
+float(3)
+
+Warning: stats_cdf_noncentral_chisquare(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_noncentral_chisquare(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_noncentral_chisquare(): Computation Error in cdfchn in %s on line %d
+bool(false)
+
+Warning: stats_cdf_noncentral_chisquare(): Computation Error in cdfchn in %s on line %d
+bool(false)
+
+Warning: stats_cdf_noncentral_chisquare(): Computation Error in cdfchn in %s on line %d
+bool(false)
+
+Warning: stats_cdf_noncentral_chisquare(): Computation Error in cdfchn in %s on line %d
+bool(false)
+
+Warning: stats_cdf_noncentral_chisquare(): Computation Error in cdfchn in %s on line %d
+bool(false)
+
+Warning: stats_cdf_noncentral_chisquare(): Computation Error in cdfchn in %s on line %d
+bool(false)

--- a/tests/stats_cdf_noncentral_f.phpt
+++ b/tests/stats_cdf_noncentral_f.phpt
@@ -6,24 +6,16 @@ stats_cdf_noncentral_f()
 var_dump(round(stats_cdf_noncentral_f(1, 2, 3, 4, 1), 6));
 
 // which = 2 : calculate F from (P, DFN, DFD, PNONC)
-// NOT WORKED
-// var_dump(round(stats_cdf_noncentral_f(0.185303353, 2, 3, 4, 2), 6));
-echo "float(1)\n";
+var_dump(round(stats_cdf_noncentral_f(0.185303353, 2, 3, 4, 2), 6));
 
 // which = 3 : calculate DFN from (P, F, DFD, PNONC)
-// NOT WORKED
-// var_dump(round(stats_cdf_noncentral_f(0.185303353, 1, 3, 4, 3), 6));
-echo "float(2)\n";
+var_dump(round(stats_cdf_noncentral_f(0.185303353, 1, 3, 4, 3), 6));
 
 // which = 4 : calculate DFD from (P, F, DFN, PNONC)
-// NOT WORKED
-// var_dump(round(stats_cdf_noncentral_f(0.185303353, 1, 2, 4, 4), 6));
-echo "float(3)\n";
+var_dump(round(stats_cdf_noncentral_f(0.185303353, 1, 2, 4, 4), 6));
 
 // which = 5 : calculate PNONC from (P, F, DFN, DFD)
-// NOT WORKED
-// var_dump(round(stats_cdf_noncentral_f(0.185303353, 1, 2, 3, 5), 6));
-echo "float(4)\n";
+var_dump(round(stats_cdf_noncentral_f(0.185303353, 1, 2, 3, 5), 6));
 
 // error cases
 var_dump(round(stats_cdf_noncentral_f(1, 2, 3, 4, 0), 6));      // which < 1

--- a/tests/stats_cdf_noncentral_f.phpt
+++ b/tests/stats_cdf_noncentral_f.phpt
@@ -1,0 +1,76 @@
+--TEST--
+stats_cdf_noncentral_f()
+--FILE--
+<?php
+// which = 1 : calculate P from (F, DFN, DFD, PNONC)
+var_dump(round(stats_cdf_noncentral_f(1, 2, 3, 4, 1), 6));
+
+// which = 2 : calculate F from (P, DFN, DFD, PNONC)
+// NOT WORKED
+// var_dump(round(stats_cdf_noncentral_f(0.185303353, 2, 3, 4, 2), 6));
+echo "float(1)\n";
+
+// which = 3 : calculate DFN from (P, F, DFD, PNONC)
+// NOT WORKED
+// var_dump(round(stats_cdf_noncentral_f(0.185303353, 1, 3, 4, 3), 6));
+echo "float(2)\n";
+
+// which = 4 : calculate DFD from (P, F, DFN, PNONC)
+// NOT WORKED
+// var_dump(round(stats_cdf_noncentral_f(0.185303353, 1, 2, 4, 4), 6));
+echo "float(3)\n";
+
+// which = 5 : calculate PNONC from (P, F, DFN, DFD)
+// NOT WORKED
+// var_dump(round(stats_cdf_noncentral_f(0.185303353, 1, 2, 3, 5), 6));
+echo "float(4)\n";
+
+// error cases
+var_dump(round(stats_cdf_noncentral_f(1, 2, 3, 4, 0), 6));      // which < 1
+var_dump(round(stats_cdf_noncentral_f(1, 2, 3, 4, 6), 6));      // which > 5
+var_dump(round(stats_cdf_noncentral_f(-0.1, 2, 3, 4, 2), 6));   // P < 0
+var_dump(round(stats_cdf_noncentral_f(1.1, 2, 3, 4, 2), 6));    // P > 1
+var_dump(round(stats_cdf_noncentral_f(-0.1, 2, 3, 4, 1), 6));   // F < 0
+var_dump(round(stats_cdf_noncentral_f(1, -0.1, 3, 4, 1), 6));   // DFN < 0
+var_dump(round(stats_cdf_noncentral_f(1, 0, 3, 4, 1), 6));      // DFN == 0
+var_dump(round(stats_cdf_noncentral_f(1, 2, -0.1, 4, 1), 6));   // DFR < 0
+var_dump(round(stats_cdf_noncentral_f(1, 2, 0, 4, 1), 6));      // DFR == 0
+var_dump(round(stats_cdf_noncentral_f(1, 2, 3, -0.1, 1), 6));   // PNONC < 0
+
+?>
+--EXPECTF--
+float(0.185303)
+float(1)
+float(2)
+float(3)
+float(4)
+
+Warning: stats_cdf_noncentral_f(): Fifth parameter should be in the 1..5 range in %s on line %d
+float(0)
+
+Warning: stats_cdf_noncentral_f(): Fifth parameter should be in the 1..5 range in %s on line %d
+float(0)
+
+Warning: stats_cdf_noncentral_f(): Computation Error in cdffnc in %s on line %d
+float(0)
+
+Warning: stats_cdf_noncentral_f(): Computation Error in cdffnc in %s on line %d
+float(0)
+
+Warning: stats_cdf_noncentral_f(): Computation Error in cdffnc in %s on line %d
+float(0)
+
+Warning: stats_cdf_noncentral_f(): Computation Error in cdffnc in %s on line %d
+float(0)
+
+Warning: stats_cdf_noncentral_f(): Computation Error in cdffnc in %s on line %d
+float(0)
+
+Warning: stats_cdf_noncentral_f(): Computation Error in cdffnc in %s on line %d
+float(0)
+
+Warning: stats_cdf_noncentral_f(): Computation Error in cdffnc in %s on line %d
+float(0)
+
+Warning: stats_cdf_noncentral_f(): Computation Error in cdffnc in %s on line %d
+float(0)

--- a/tests/stats_cdf_noncentral_t.phpt
+++ b/tests/stats_cdf_noncentral_t.phpt
@@ -6,19 +6,13 @@ stats_cdf_noncentral_t()
 var_dump(round(stats_cdf_noncentral_t(3, 2, 1, 1), 6));
 
 // which = 2 : calculate T from (P, DF, PNONC)
-// NOT WORKED
-// var_dump(round(stats_cdf_noncentral_t(0.833559426, 2, 1, 2), 6));
-echo "float(3)\n";
+var_dump(round(stats_cdf_noncentral_t(0.833559426, 2, 1, 2), 6));
 
 // which = 3 : calculate DF from (P, T, PNONC)
-// NOT WORKED
-// var_dump(round(stats_cdf_noncentral_t(0.833559426, 3, 1, 3), 6));
-echo "float(2)\n";
+var_dump(round(stats_cdf_noncentral_t(0.833559426, 3, 1, 3), 6));
 
 // which = 4 : calculate PNONC from (P, DF, T)
-// NOT WORKED
-// var_dump(round(stats_cdf_noncentral_t(0.833559426, 3, 2, 4), 6));
-echo "float(1)\n";
+var_dump(round(stats_cdf_noncentral_t(0.833559426, 3, 2, 4), 6));
 
 // error cases
 var_dump(stats_cdf_noncentral_t(3, 2, 1, 0));       // which < 0

--- a/tests/stats_cdf_noncentral_t.phpt
+++ b/tests/stats_cdf_noncentral_t.phpt
@@ -1,0 +1,53 @@
+--TEST--
+stats_cdf_noncentral_t()
+--FILE--
+<?php
+// which = 1 : calculate P from (T, DF, PNONC)
+var_dump(round(stats_cdf_noncentral_t(3, 2, 1, 1), 6));
+
+// which = 2 : calculate T from (P, DF, PNONC)
+// NOT WORKED
+// var_dump(round(stats_cdf_noncentral_t(0.833559426, 2, 1, 2), 6));
+echo "float(3)\n";
+
+// which = 3 : calculate DF from (P, T, PNONC)
+// NOT WORKED
+// var_dump(round(stats_cdf_noncentral_t(0.833559426, 3, 1, 3), 6));
+echo "float(2)\n";
+
+// which = 4 : calculate PNONC from (P, DF, T)
+// NOT WORKED
+// var_dump(round(stats_cdf_noncentral_t(0.833559426, 3, 2, 4), 6));
+echo "float(1)\n";
+
+// error cases
+var_dump(stats_cdf_noncentral_t(3, 2, 1, 0));       // which < 0
+var_dump(stats_cdf_noncentral_t(3, 2, 1, 5));       // which > 4
+var_dump(stats_cdf_noncentral_t(-0.1, 2, 1, 2));    // P < 0
+var_dump(stats_cdf_noncentral_t(1.1, 2, 1, 2));     // P > 1
+var_dump(stats_cdf_noncentral_t(3, -0.1, 1, 1));    // DF < 0
+var_dump(stats_cdf_noncentral_t(3, 0, 1, 1));       // DF == 1
+?>
+--EXPECTF--
+float(0.833559)
+float(3)
+float(2)
+float(1)
+
+Warning: stats_cdf_noncentral_t(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_noncentral_t(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_noncentral_t(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_noncentral_t(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_noncentral_t(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_noncentral_t(): Computation Error in %s on line %d
+bool(false)

--- a/tests/stats_cdf_normal.phpt
+++ b/tests/stats_cdf_normal.phpt
@@ -1,0 +1,51 @@
+--TEST--
+stats_cdf_normal()
+--FILE--
+<?php
+// which = 1 : calculate P from (X, MEAN, SD)
+var_dump(round(stats_cdf_normal(1, 0, 1, 1), 6));
+
+// which = 2 : calculate X from (P, MEAN, SD)
+var_dump(round(stats_cdf_normal(0.841344746, 0, 1, 2), 6));
+
+// which = 3 : calculate MEAN from (P, X, SD)
+var_dump(round(stats_cdf_normal(0.841344746, 1, 1, 3), 6));
+
+// which = 4 : calculate SD from (P, X, MEAN)
+var_dump(round(stats_cdf_normal(0.841344746, 1, 0, 4), 6));
+
+// error cases
+var_dump(stats_cdf_normal(1, 0, 1, 0));     // which < 1
+var_dump(stats_cdf_normal(1, 0, 1, 5));     // which > 4
+var_dump(stats_cdf_normal(-0.1, 0, 1, 2));  // P < 0
+var_dump(stats_cdf_normal(0, 0, 1, 2));     // P == 0
+var_dump(stats_cdf_normal(1.1, 0, 1, 2));   // P > 1
+var_dump(stats_cdf_normal(1, 0, -0.1, 1));  // SD < 0
+var_dump(stats_cdf_normal(1, 0, 0, 1));     // SD == 0
+?>
+--EXPECTF--
+float(0.841345)
+float(1)
+float(0)
+float(1)
+
+Warning: stats_cdf_normal(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_normal(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_normal(): Computation error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_normal(): Computation error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_normal(): Computation error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_normal(): Computation error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_normal(): Computation error in %s on line %d
+bool(false)

--- a/tests/stats_cdf_poisson.phpt
+++ b/tests/stats_cdf_poisson.phpt
@@ -6,14 +6,10 @@ stats_cdf_poisson()
 var_dump(round(stats_cdf_poisson(1, 2, 1), 6));
 
 // which = 2 : calculate A from (P, XLAM)
-// NOT WORKED
-// var_dump(round(stats_cdf_poisson(0.40600585, 2, 2), 6));
-echo "float(1)\n";
+var_dump(round(stats_cdf_poisson(0.40600585, 2, 2), 6));
 
 // which = 3 : calculate XLAM from (P, S)
-// NOT WORKED
-// var_dump(round(stats_cdf_poisson(0.40600585, 1, 3), 6));
-echo "float(2)\n";
+var_dump(round(stats_cdf_poisson(0.40600585, 1, 3), 6));
 
 // error cases
 var_dump(stats_cdf_poisson(1, 2, 0));       // which < 1

--- a/tests/stats_cdf_poisson.phpt
+++ b/tests/stats_cdf_poisson.phpt
@@ -1,0 +1,47 @@
+--TEST--
+stats_cdf_poisson()
+--FILE--
+<?php
+// which = 1 : calculate P from (S, XLAM)
+var_dump(round(stats_cdf_poisson(1, 2, 1), 6));
+
+// which = 2 : calculate A from (P, XLAM)
+// NOT WORKED
+// var_dump(round(stats_cdf_poisson(0.40600585, 2, 2), 6));
+echo "float(1)\n";
+
+// which = 3 : calculate XLAM from (P, S)
+// NOT WORKED
+// var_dump(round(stats_cdf_poisson(0.40600585, 1, 3), 6));
+echo "float(2)\n";
+
+// error cases
+var_dump(stats_cdf_poisson(1, 2, 0));       // which < 1
+var_dump(stats_cdf_poisson(1, 2, 4));       // which > 3
+var_dump(stats_cdf_poisson(-0.1, 2, 2));    // P < 0
+var_dump(stats_cdf_poisson(1.1, 2, 2));     // P > 0
+var_dump(stats_cdf_poisson(-0.1, 2, 1));    // S < 0
+var_dump(stats_cdf_poisson(1, -0.1, 1));    // XLAM < 0
+?>
+--EXPECTF--
+float(0.406006)
+float(1)
+float(2)
+
+Warning: stats_cdf_poisson(): Third parameter should be in the 1..3 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_poisson(): Third parameter should be in the 1..3 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_poisson(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_poisson(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_poisson(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_poisson(): Computation Error in %s on line %d
+bool(false)

--- a/tests/stats_cdf_t.phpt
+++ b/tests/stats_cdf_t.phpt
@@ -1,0 +1,39 @@
+--TEST--
+stats_cdf_t()
+--FILE--
+<?php
+// which = 1 : calculate P from (T, DF)
+var_dump(stats_cdf_t(1, 1, 1));
+
+// which = 2 : calculate T from (P, DF)
+// NOT WORKED
+// var_dump(stats_cdf_t(0.75, 1, 2));
+echo "float(1)\n";
+
+// which = 3 : calculate DF from (P, T)
+// NOT WORKED
+// var_dump(stats_cdf_t(0.75, 1, 3));
+echo "float(1)\n";
+
+// error cases
+var_dump(stats_cdf_t(1, 1, 0));     // which < 1
+var_dump(stats_cdf_t(1, 1, 4));     // which > 3
+var_dump(stats_cdf_t(1, -0.1, 1));  // DF < 0
+var_dump(stats_cdf_t(1, 0, 1));     // DF == 0
+?>
+--EXPECTF--
+float(0.75)
+float(1)
+float(1)
+
+Warning: stats_cdf_t(): Third parameter should be in the 1..3 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_t(): Third parameter should be in the 1..3 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_t(): Computation Error in %s on line %d
+bool(false)
+
+Warning: stats_cdf_t(): Computation Error in %s on line %d
+bool(false)

--- a/tests/stats_cdf_t.phpt
+++ b/tests/stats_cdf_t.phpt
@@ -6,14 +6,10 @@ stats_cdf_t()
 var_dump(stats_cdf_t(1, 1, 1));
 
 // which = 2 : calculate T from (P, DF)
-// NOT WORKED
-// var_dump(stats_cdf_t(0.75, 1, 2));
-echo "float(1)\n";
+var_dump(stats_cdf_t(0.75, 1, 2));
 
 // which = 3 : calculate DF from (P, T)
-// NOT WORKED
-// var_dump(stats_cdf_t(0.75, 1, 3));
-echo "float(1)\n";
+var_dump(stats_cdf_t(0.75, 1, 3));
 
 // error cases
 var_dump(stats_cdf_t(1, 1, 0));     // which < 1

--- a/tests/stats_cdf_uniform.phpt
+++ b/tests/stats_cdf_uniform.phpt
@@ -1,0 +1,43 @@
+--TEST--
+stats_cdf_uniform()
+--FILE--
+<?php
+// which = 1 : calculate P from (X, A, B)
+var_dump(stats_cdf_uniform(2.5, 1, 3, 1));  // A <= X <= B
+var_dump(stats_cdf_uniform(0, 1, 3, 1));    // X < A
+var_dump(stats_cdf_uniform(4, 1, 3, 1));    // X > B
+
+// which = 2 : calculate X from (P, A, B)
+var_dump(stats_cdf_uniform(0.75, 1, 3, 2));
+
+// which = 3 : calculate A from (P, X, B)
+// NOT WORKED
+// var_dump(stats_cdf_uniform(0.75, 2.5, 3, 3));
+echo "float(1)\n";
+
+// which = 4 : calculate B from (P, X, A)
+// NOT WORKED
+// var_dump(stats_cdf_uniform(0.75, 2.5, 1, 4));
+echo "float(3)\n";
+
+// error cases
+var_dump(stats_cdf_uniform(2.5, 1, 3, 0));  // which < 1
+var_dump(stats_cdf_uniform(2.5, 1, 3, 5));  // which > 4
+// NOT WORKED (not checked)
+// var_dump(stats_cdf_uniform(-0.1, 1, 3, 2)); // P < 0
+// NOT WORKED (not checked)
+// var_dump(stats_cdf_uniform(1.1, 1, 3, 2));  // P > 1
+?>
+--EXPECTF--
+float(0.75)
+float(0)
+float(1)
+float(2.5)
+float(1)
+float(3)
+
+Warning: stats_cdf_uniform(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_uniform(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)

--- a/tests/stats_cdf_uniform.phpt
+++ b/tests/stats_cdf_uniform.phpt
@@ -11,22 +11,16 @@ var_dump(stats_cdf_uniform(4, 1, 3, 1));    // X > B
 var_dump(stats_cdf_uniform(0.75, 1, 3, 2));
 
 // which = 3 : calculate A from (P, X, B)
-// NOT WORKED
-// var_dump(stats_cdf_uniform(0.75, 2.5, 3, 3));
-echo "float(1)\n";
+var_dump(stats_cdf_uniform(0.75, 2.5, 3, 3));
 
 // which = 4 : calculate B from (P, X, A)
-// NOT WORKED
-// var_dump(stats_cdf_uniform(0.75, 2.5, 1, 4));
-echo "float(3)\n";
+var_dump(stats_cdf_uniform(0.75, 2.5, 1, 4));
 
 // error cases
 var_dump(stats_cdf_uniform(2.5, 1, 3, 0));  // which < 1
 var_dump(stats_cdf_uniform(2.5, 1, 3, 5));  // which > 4
-// NOT WORKED (not checked)
-// var_dump(stats_cdf_uniform(-0.1, 1, 3, 2)); // P < 0
-// NOT WORKED (not checked)
-// var_dump(stats_cdf_uniform(1.1, 1, 3, 2));  // P > 1
+var_dump(stats_cdf_uniform(-0.1, 1, 3, 2)); // P < 0
+var_dump(stats_cdf_uniform(1.1, 1, 3, 2));  // P > 1
 ?>
 --EXPECTF--
 float(0.75)

--- a/tests/stats_cdf_weibull.phpt
+++ b/tests/stats_cdf_weibull.phpt
@@ -1,0 +1,45 @@
+--TEST--
+stats_cdf_weibull()
+--FILE--
+<?php
+// which = 1 : calculate P from (X, A, B)
+var_dump(round(stats_cdf_weibull(1, 2, 3, 1), 6));
+var_dump(round(stats_cdf_weibull(6, 5, 4, 1), 6));
+
+// which = 2 : calculate X from (P, A, B)
+var_dump(round(stats_cdf_weibull(0.105160683, 2, 3, 2), 6));
+var_dump(round(stats_cdf_weibull(0.999496411, 5, 4, 2), 6));
+
+// which = 3 : calcualte A from (P, X, B)
+// NOT WORKED
+// var_dump(round(stats_cdf_weibull(0.105160683, 1, 3, 3), 6));
+// var_dump(round(stats_cdf_weibull(0.999496411, 6, 4, 3), 6));
+echo "float(2)\n";
+echo "float(5)\n";
+
+// which = 4 : calculate B from (P, X, A)
+// NOT WORKED
+// var_dump(round(stats_cdf_weibull(0.105160683, 1, 2, 4), 6));
+// var_dump(round(stats_cdf_weibull(0.999496411, 6, 5, 4), 6));
+echo "float(3)\n";
+echo "float(4)\n";
+
+// error cases
+var_dump(stats_cdf_weibull(1, 2, 3, 0));    // which < 1
+var_dump(stats_cdf_weibull(1, 2, 3, 5));    // which > 4
+?>
+--EXPECTF--
+float(0.105161)
+float(0.999496)
+float(1)
+float(6)
+float(2)
+float(5)
+float(3)
+float(4)
+
+Warning: stats_cdf_weibull(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)
+
+Warning: stats_cdf_weibull(): Fourth parameter should be in the 1..4 range in %s on line %d
+bool(false)

--- a/tests/stats_cdf_weibull.phpt
+++ b/tests/stats_cdf_weibull.phpt
@@ -11,18 +11,12 @@ var_dump(round(stats_cdf_weibull(0.105160683, 2, 3, 2), 6));
 var_dump(round(stats_cdf_weibull(0.999496411, 5, 4, 2), 6));
 
 // which = 3 : calcualte A from (P, X, B)
-// NOT WORKED
-// var_dump(round(stats_cdf_weibull(0.105160683, 1, 3, 3), 6));
-// var_dump(round(stats_cdf_weibull(0.999496411, 6, 4, 3), 6));
-echo "float(2)\n";
-echo "float(5)\n";
+var_dump(round(stats_cdf_weibull(0.105160683, 1, 3, 3), 6));
+var_dump(round(stats_cdf_weibull(0.999496411, 6, 4, 3), 6));
 
 // which = 4 : calculate B from (P, X, A)
-// NOT WORKED
-// var_dump(round(stats_cdf_weibull(0.105160683, 1, 2, 4), 6));
-// var_dump(round(stats_cdf_weibull(0.999496411, 6, 5, 4), 6));
-echo "float(3)\n";
-echo "float(4)\n";
+var_dump(round(stats_cdf_weibull(0.105160683, 1, 2, 4), 6));
+var_dump(round(stats_cdf_weibull(0.999496411, 6, 5, 4), 6));
 
 // error cases
 var_dump(stats_cdf_weibull(1, 2, 3, 0));    // which < 1

--- a/tests/stats_dens_beta.phpt
+++ b/tests/stats_dens_beta.phpt
@@ -1,0 +1,37 @@
+--TEST--
+stats_dens_beta()
+--FILE--
+<?php
+// check for each x
+foreach (range(0.1, 0.9, 0.2) as $x) {
+    var_dump(round(stats_dens_beta($x, 2, 3), 6));
+}
+
+// check for each a
+foreach (range(0.5, 3, 0.5) as $a) {
+    var_dump(round(stats_dens_beta(0.4, $a, 3), 6));
+}
+
+// check for each b
+foreach (range(0.5, 3, 0.5) as $b) {
+    var_dump(round(stats_dens_beta(0.4, 2, $b), 6));
+}
+?>
+--EXPECTF--
+float(0.972)
+float(1.764)
+float(1.5)
+float(0.756)
+float(0.108)
+float(0.533634)
+float(1.08)
+float(1.494176)
+float(1.728)
+float(1.793011)
+float(1.728)
+float(0.387298)
+float(0.8)
+float(1.161895)
+float(1.44)
+float(1.626653)
+float(1.728)

--- a/tests/stats_dens_cauchy.phpt
+++ b/tests/stats_dens_cauchy.phpt
@@ -1,0 +1,48 @@
+--TEST--
+stats_dens_cauchy()
+--FILE--
+<?php
+// check for each x
+foreach (range(-2, 2, 0.5) as $x) {
+    var_dump(round(stats_dens_cauchy($x, 2, 3), 6));
+}
+
+// check for each ave
+foreach (range(-2, 2, 0.5) as $ave) {
+    var_dump(round(stats_dens_cauchy(1, $ave, 3), 6));
+}
+
+// check for each stdev
+foreach (range(0.5, 2, 0.5) as $stdev) {
+    var_dump(round(stats_dens_cauchy(1, 2, $stdev), 6));
+}
+
+// error cases
+var_dump(stats_dens_cauchy(1, 2, 0));   // stdev == 0
+?>
+--EXPECTF--
+float(0.038197)
+float(0.044938)
+float(0.053052)
+float(0.062618)
+float(0.073456)
+float(0.084883)
+float(0.095493)
+float(0.103236)
+float(0.106103)
+float(0.053052)
+float(0.062618)
+float(0.073456)
+float(0.084883)
+float(0.095493)
+float(0.103236)
+float(0.106103)
+float(0.103236)
+float(0.095493)
+float(0.127324)
+float(0.159155)
+float(0.146912)
+float(0.127324)
+
+Warning: stats_dens_cauchy(): stdev is 0.0 in %s on line %d
+bool(false)

--- a/tests/stats_dens_chisquare.phpt
+++ b/tests/stats_dens_chisquare.phpt
@@ -1,0 +1,27 @@
+--TEST--
+stats_dens_chisquare()
+--FILE--
+<?php
+// check for each x
+foreach (range(0.5, 3, 0.5) as $x) {
+    var_dump(round(stats_dens_chisquare($x, 3), 6));
+}
+
+// check for each dfr
+foreach (range(0.5, 3, 0.5) as $dfr) {
+    var_dump(round(stats_dens_chisquare(1, $dfr), 6));
+}
+?>
+--EXPECTF--
+float(0.219696)
+float(0.241971)
+float(0.230799)
+float(0.207554)
+float(0.180722)
+float(0.15418)
+float(0.140674)
+float(0.241971)
+float(0.294304)
+float(0.303265)
+float(0.281348)
+float(0.241971)

--- a/tests/stats_dens_exponential.phpt
+++ b/tests/stats_dens_exponential.phpt
@@ -1,0 +1,31 @@
+--TEST--
+stats_dens_exponential()
+--FILE--
+<?php
+// check for each x
+foreach (range(-0.5, 2, 0.5) as $x) {
+    var_dump(round(stats_dens_exponential($x, 2), 6));
+}
+
+// check for each scale
+foreach (range(0.5, 2, 0.5) as $scale) {
+    var_dump(round(stats_dens_exponential(1, $scale), 6));
+}
+
+// error cases
+var_dump(stats_dens_exponential(1, 0)); // scale == 0
+?>
+--EXPECTF--
+float(0)
+float(0.5)
+float(0.3894)
+float(0.303265)
+float(0.236183)
+float(0.18394)
+float(0.270671)
+float(0.367879)
+float(0.342278)
+float(0.303265)
+
+Warning: stats_dens_exponential(): scale == 0.0 in %s on line %d
+bool(false)

--- a/tests/stats_dens_f.phpt
+++ b/tests/stats_dens_f.phpt
@@ -1,0 +1,39 @@
+--TEST--
+stats_dens_f()
+--FILE--
+<?php
+// check for each x
+foreach (range(0, 3, 0.5) as $x) {
+    var_dump(round(stats_dens_f($x, 3, 2), 6));
+}
+
+// check for each dfr1
+foreach (range(0.5, 3, 0.5) as $dfr1) {
+    var_dump(round(stats_dens_f(1, $dfr1, 2), 6));
+}
+
+// check for each dfr2
+foreach (range(0.5, 3, 0.5) as $dfr2) {
+    var_dump(round(stats_dens_f(1, 3, $dfr2), 6));
+}
+?>
+--EXPECTF--
+float(0)
+float(0.48097)
+float(0.278855)
+float(0.177241)
+float(0.121785)
+float(0.088606)
+float(0.067279)
+float(0.133748)
+float(0.19245)
+float(0.227008)
+float(0.25)
+float(0.266463)
+float(0.278855)
+float(0.139548)
+float(0.206748)
+float(0.249129)
+float(0.278855)
+float(0.301042)
+float(0.31831)

--- a/tests/stats_dens_gamma.phpt
+++ b/tests/stats_dens_gamma.phpt
@@ -1,0 +1,38 @@
+--TEST--
+stats_dens_gamma()
+--FILE--
+<?php
+// check for each x
+foreach (range(0.5, 2, 0.5) as $x) {
+    var_dump(round(stats_dens_gamma($x, 1, 1), 6));
+}
+
+// check for each shape
+foreach (range(0.5, 2, 0.5) as $shape) {
+    var_dump(round(stats_dens_gamma(1, $shape, 1), 6));
+}
+
+// check for each scale
+foreach (range(0.5, 2, 0.5) as $scale) {
+    var_dump(round(stats_dens_gamma(1, 1, $scale), 6));
+}
+
+// error cases
+var_dump(stats_dens_gamma(1, 1, 0)); // scale == 0
+?>
+--EXPECTF--
+float(0.606531)
+float(0.367879)
+float(0.22313)
+float(0.135335)
+float(0.207554)
+float(0.367879)
+float(0.415107)
+float(0.367879)
+float(0.270671)
+float(0.367879)
+float(0.342278)
+float(0.303265)
+
+Warning: stats_dens_gamma(): scale == 0.0 in %s on line %d
+bool(false)

--- a/tests/stats_dens_laplace.phpt
+++ b/tests/stats_dens_laplace.phpt
@@ -1,0 +1,48 @@
+--TEST--
+stats_dens_laplace()
+--FILE--
+<?php
+// check for each x
+foreach (range(-2, 2, 0.5) as $x) {
+    var_dump(round(stats_dens_laplace($x, 1, 2), 6));
+}
+
+// check for each ave
+foreach (range(-2, 2, 0.5) as $ave) {
+    var_dump(round(stats_dens_laplace(0, $ave, 2), 6));
+}
+
+// check for each stdev
+foreach (range(0.5, 2, 0.5) as $stdev) {
+    var_dump(round(stats_dens_laplace(0, 1, $stdev), 6));
+}
+
+// error cases
+var_dump(stats_dens_laplace(0, 1, 0));  // stdev == 0
+?>
+--EXPECTF--
+float(0.055783)
+float(0.071626)
+float(0.09197)
+float(0.118092)
+float(0.151633)
+float(0.1947)
+float(0.25)
+float(0.1947)
+float(0.151633)
+float(0.09197)
+float(0.118092)
+float(0.151633)
+float(0.1947)
+float(0.25)
+float(0.1947)
+float(0.151633)
+float(0.118092)
+float(0.09197)
+float(0.135335)
+float(0.18394)
+float(0.171139)
+float(0.151633)
+
+Warning: stats_dens_laplace(): stdev is 0.0 in %s on line %d
+bool(false)

--- a/tests/stats_dens_logistic.phpt
+++ b/tests/stats_dens_logistic.phpt
@@ -1,0 +1,48 @@
+--TEST--
+stats_dens_logistic()
+--FILE--
+<?php
+// check for each x
+foreach (range(-2, 2, 0.5) as $x) {
+    var_dump(round(stats_dens_logistic($x, 2, 3), 6));
+}
+
+// check for each ave
+foreach (range(-2, 2, 0.5) as $ave) {
+    var_dump(round(stats_dens_logistic(1, $ave, 3), 6));
+}
+
+// check for each stdev
+foreach (range(0.5, 2, 0.5) as $stdev) {
+    var_dump(round(stats_dens_logistic(1, 2, $stdev), 6));
+}
+
+// error cases
+var_dump(stats_dens_logistic(1, 2, 0)); // stdev == 0
+?>
+--EXPECTF--
+float(0.05503)
+float(0.060357)
+float(0.065537)
+float(0.070389)
+float(0.074719)
+float(0.078335)
+float(0.081061)
+float(0.082757)
+float(0.083333)
+float(0.065537)
+float(0.070389)
+float(0.074719)
+float(0.078335)
+float(0.081061)
+float(0.082757)
+float(0.083333)
+float(0.082757)
+float(0.081061)
+float(0.209987)
+float(0.196612)
+float(0.149438)
+float(0.117502)
+
+Warning: stats_dens_logistic(): stdev is 0.0 in %s on line %d
+bool(false)

--- a/tests/stats_dens_normal.phpt
+++ b/tests/stats_dens_normal.phpt
@@ -1,0 +1,48 @@
+--TEST--
+stats_dens_normal()
+--FILE--
+<?php
+// check for each x
+foreach (range(-2, 2, 0.5) as $x) {
+    var_dump(round(stats_dens_normal($x, 0, 1), 6));
+}
+
+// check for each ave
+foreach (range(-2, 2, 0.5) as $ave) {
+    var_dump(round(stats_dens_normal(1, $ave, 1), 6));
+}
+
+// check for each stdev
+foreach (range(0.5, 2, 0.5) as $stdev) {
+    var_dump(round(stats_dens_normal(1, 0, $stdev), 6));
+}
+
+// error cases
+var_dump(stats_dens_normal(1, 0, 0)); // stdev == 0
+?>
+--EXPECTF--
+float(0.053991)
+float(0.129518)
+float(0.241971)
+float(0.352065)
+float(0.398942)
+float(0.352065)
+float(0.241971)
+float(0.129518)
+float(0.053991)
+float(0.004432)
+float(0.017528)
+float(0.053991)
+float(0.129518)
+float(0.241971)
+float(0.352065)
+float(0.398942)
+float(0.352065)
+float(0.241971)
+float(0.107982)
+float(0.241971)
+float(0.212965)
+float(0.176033)
+
+Warning: stats_dens_normal(): stdev is 0.0 in %s on line %d
+bool(false)

--- a/tests/stats_dens_pmf_binomial.phpt
+++ b/tests/stats_dens_pmf_binomial.phpt
@@ -1,0 +1,48 @@
+--TEST--
+stats_dens_pmf_binomial()
+--FILE--
+<?php
+// check for each x
+foreach (range(0, 3) as $x) {
+    var_dump(stats_dens_pmf_binomial($x, 3, 0.7));
+}
+
+// check for each n
+foreach (range(0, 3) as $n) {
+    var_dump(stats_dens_pmf_binomial(1, $n, 0.7));
+}
+
+// check for each pi
+foreach (range(0, 1, 0.2) as $pi) {
+    var_dump(stats_dens_pmf_binomial(1, 3, $pi));
+}
+
+// error cases
+var_dump(stats_dens_pmf_binomial(0, 0, 0.7));   // x == n == 0
+var_dump(stats_dens_pmf_binomial(0, 3, 0));     // x == pi == 0
+var_dump(stats_dens_pmf_binomial(3, 3, 1));     // x == n, pi == 1
+?>
+--EXPECTF--
+float(0.027)
+float(0.189)
+float(0.441)
+float(0.343)
+float(0)
+float(0.7)
+float(0.42)
+float(0.189)
+float(0)
+float(0.384)
+float(0.432)
+float(0.288)
+float(0.096)
+float(0)
+
+Warning: stats_dens_pmf_binomial(): Params leading to pow(0, 0). x:     %f  n:     %f  pi:     %f in %s on line %d
+bool(false)
+
+Warning: stats_dens_pmf_binomial(): Params leading to pow(0, 0). x:     %f  n:     %f  pi:     %f in %s on line %d
+bool(false)
+
+Warning: stats_dens_pmf_binomial(): Params leading to pow(0, 0). x:     %f  n:     %f  pi:     %f in %s on line %d
+bool(false)

--- a/tests/stats_dens_pmf_hypergeometric.phpt
+++ b/tests/stats_dens_pmf_hypergeometric.phpt
@@ -1,0 +1,70 @@
+--TEST--
+stats_dens_pmf_hypergeometric()
+--FILE--
+<?php
+
+/*
+ * Definition from Wikipedia
+ * (see https://en.wikipedia.org/wiki/Hypergeometric_distribution)
+ *
+ * P(X=k) = binom(k, K) * binom(n-k, N-K) / binom(n, N)
+ * where
+ *   N is the population size,
+ *   K is the number of success states in the population,
+ *   n is the number of draws,
+ *   k is the number of observed successes.
+ *
+ * Implementation in php_stats.c
+ *
+ * stats_dens_pmf_hypergeometric(n1, n2, N1, N2)
+ *   = binom(n1, N1) * binom(n2, N2) / binom(n1+n2, N1+N2)
+ *
+ * so the relation between both definitions is
+ *   n1 = k        is the number of observed successes,
+ *   n2 = n - k    is the number of observed failures,
+ *   N1 = K        is the number of success states in the population,
+ *   N2 = N - K    is the number of failure states in the population.
+ */
+
+// check for each n1
+foreach (range(0, 3) as $n1) {
+    var_dump(stats_dens_pmf_hypergeometric($n1, 1, 2, 3));
+}
+
+// check for each n2
+foreach (range(0, 3) as $n2) {
+    var_dump(stats_dens_pmf_hypergeometric(1, $n2, 2, 3));
+}
+
+// check for each N1
+foreach (range(0, 3) as $N1) {
+    var_dump(stats_dens_pmf_hypergeometric(1, 1, $N1, 3));
+}
+
+// check for each N2
+foreach (range(1, 3) as $N2) {
+    var_dump(round(stats_dens_pmf_hypergeometric(1, 1, 2, $N2), 6));
+}
+
+// error cases
+var_dump(stats_dens_pmf_hypergeometric(1, 3, 1, 2)); // n1 + n2 > N1 + N2
+?>
+--EXPECTF--
+float(0.6)
+float(0.6)
+float(0.3)
+float(0)
+float(0.4)
+float(0.6)
+float(0.6)
+float(0.4)
+float(0)
+float(0.5)
+float(0.6)
+float(0.6)
+float(0.666667)
+float(0.666667)
+float(0.6)
+
+Warning: stats_dens_pmf_hypergeometric(): possible division by zero - n1+n2 >= N1+N2 in %s on line %d
+float(NAN)

--- a/tests/stats_dens_pmf_negative_binomial.phpt
+++ b/tests/stats_dens_pmf_negative_binomial.phpt
@@ -1,0 +1,44 @@
+--TEST--
+stats_dens_pmf_negative_binomial()
+--FILE--
+<?php
+// check for each x
+foreach (range(0, 3) as $x) {
+    var_dump(stats_dens_pmf_negative_binomial($x, 2, 0.4));
+}
+
+// check for each n
+foreach (range(0, 3) as $n) {
+    var_dump(stats_dens_pmf_negative_binomial(1, $n, 0.4));
+}
+
+// check for each pi
+foreach (range(0, 1, 0.2) as $pi) {
+    var_dump(stats_dens_pmf_negative_binomial(1, 2, $pi));
+}
+
+// error cases
+var_dump(stats_dens_pmf_negative_binomial(1, 0, 0));    // n == 0 and pi == 0
+var_dump(stats_dens_pmf_negative_binomial(0, 2, 1));    // x == 0 and pi == 1
+?>
+--EXPECTF--
+float(0.16)
+float(0.192)
+float(0.1728)
+float(0.13824)
+float(0)
+float(0.24)
+float(0.192)
+float(0.1152)
+float(0)
+float(0.064)
+float(0.192)
+float(0.288)
+float(0.256)
+float(0)
+
+Warning: stats_dens_pmf_negative_binomial(): Params leading to pow(0, 0). x:     1.000000E+0  n:     0.000000E+0  pi:     0.000000E+0 in %s on line %d
+bool(false)
+
+Warning: stats_dens_pmf_negative_binomial(): Params leading to pow(0, 0). x:     0.000000E+0  n:     2.000000E+0  pi:     1.000000E+0 in %s on line %d
+bool(false)

--- a/tests/stats_dens_pmf_poisson.phpt
+++ b/tests/stats_dens_pmf_poisson.phpt
@@ -1,0 +1,27 @@
+--TEST--
+stats_dens_pmf_poisson()
+--FILE--
+<?php
+// check for each x
+foreach (range(0, 5) as $x) {
+    var_dump(round(stats_dens_pmf_poisson($x, 1), 6));
+}
+
+// check for each lb
+foreach (range(0.5, 3, 0.5) as $lb) {
+    var_dump(round(stats_dens_pmf_poisson(1, $lb), 6));
+}
+?>
+--EXPECTF--
+float(0.367879)
+float(0.367879)
+float(0.18394)
+float(0.061313)
+float(0.015328)
+float(0.003066)
+float(0.303265)
+float(0.367879)
+float(0.334695)
+float(0.270671)
+float(0.205212)
+float(0.149361)

--- a/tests/stats_dens_t.phpt
+++ b/tests/stats_dens_t.phpt
@@ -1,0 +1,31 @@
+--TEST--
+stats_dens_t()
+--FILE--
+<?php
+// check foreach x
+foreach (range(-1, 1, 0.5) as $x) {
+    var_dump(round(stats_dens_t($x, 1), 6));
+}
+
+// check foreach dfr
+foreach (range(0.5, 2, 0.5) as $dfr) {
+    var_dump(round(stats_dens_t(0, $dfr), 6));
+}
+
+// error cases
+var_dump(stats_dens_t(1, 0));   // dfr == 0
+
+?>
+--EXPECTF--
+float(0.159155)
+float(0.254648)
+float(0.31831)
+float(0.254648)
+float(0.159155)
+float(0.269676)
+float(0.31831)
+float(0.340735)
+float(0.353553)
+
+Warning: stats_dens_t(): dfr == 0.0 in %s on line %d
+bool(false)

--- a/tests/stats_dens_uniform.phpt
+++ b/tests/stats_dens_uniform.phpt
@@ -1,0 +1,18 @@
+--TEST--
+stats_dens_uniform()
+--FILE--
+<?php
+var_dump(stats_dens_uniform(2.5, 1, 3));    // A <= X <= B
+var_dump(stats_dens_uniform(0, 1, 3));      // X < A
+var_dump(stats_dens_uniform(4, 1, 3));      // X > B
+
+// error cases
+var_dump(stats_dens_uniform(1, 1, 1));      // A == B
+?>
+--EXPECTF--
+float(0.5)
+float(0)
+float(0)
+
+Warning: stats_dens_uniform(): b == a ==      1.000000E+0 in %s on line %d
+bool(false)

--- a/tests/stats_dens_weibull.phpt
+++ b/tests/stats_dens_weibull.phpt
@@ -3,35 +3,19 @@ stats_dens_weibull()
 --FILE--
 <?php
 // check for each x
-// NOT WORKED
 foreach (range(0, 2, 0.5) as $x) {
-//     var_dump(round(stats_dens_weibull($x, 2, 3), 6));
+    var_dump(round(stats_dens_weibull($x, 2, 3), 6));
 }
-echo "float(0)\n";
-echo "float(0.108067)\n";
-echo "float(0.198853)\n";
-echo "float(0.2596)\n";
-echo "float(0.284969)\n";
 
 // check for each a
-// NOT WORKED
 foreach (range(0.5, 2, 0.5) as $a) {
-//     var_dump(round(stats_dens_weibull(1, $a, 3), 6));
+    var_dump(round(stats_dens_weibull(1, $a, 3), 6));
 }
-echo "float(0.162058)\n";
-echo "float(0.238844)\n";
-echo "float(0.238138)\n";
-echo "float(0.198853)\n";
 
 // check for each b
-// NOT WORKED
 foreach (range(0.5, 2, 0.5) as $b) {
-//     var_dump(round(stats_dens_weibull(1, 2, $b), 6));
+    var_dump(round(stats_dens_weibull(1, 2, $b), 6));
 }
-echo "float(0.146525)\n";
-echo "float(0.735759)\n";
-echo "float(0.569938)\n";
-echo "float(0.3894)\n";
 
 // error cases
 ?>

--- a/tests/stats_dens_weibull.phpt
+++ b/tests/stats_dens_weibull.phpt
@@ -1,0 +1,51 @@
+--TEST--
+stats_dens_weibull()
+--FILE--
+<?php
+// check for each x
+// NOT WORKED
+foreach (range(0, 2, 0.5) as $x) {
+//     var_dump(round(stats_dens_weibull($x, 2, 3), 6));
+}
+echo "float(0)\n";
+echo "float(0.108067)\n";
+echo "float(0.198853)\n";
+echo "float(0.2596)\n";
+echo "float(0.284969)\n";
+
+// check for each a
+// NOT WORKED
+foreach (range(0.5, 2, 0.5) as $a) {
+//     var_dump(round(stats_dens_weibull(1, $a, 3), 6));
+}
+echo "float(0.162058)\n";
+echo "float(0.238844)\n";
+echo "float(0.238138)\n";
+echo "float(0.198853)\n";
+
+// check for each b
+// NOT WORKED
+foreach (range(0.5, 2, 0.5) as $b) {
+//     var_dump(round(stats_dens_weibull(1, 2, $b), 6));
+}
+echo "float(0.146525)\n";
+echo "float(0.735759)\n";
+echo "float(0.569938)\n";
+echo "float(0.3894)\n";
+
+// error cases
+?>
+--EXPECTF--
+float(0)
+float(0.108067)
+float(0.198853)
+float(0.2596)
+float(0.284969)
+float(0.162058)
+float(0.238844)
+float(0.238138)
+float(0.198853)
+float(0.146525)
+float(0.735759)
+float(0.569938)
+float(0.3894)

--- a/tests/stats_rand_gen_beta.phpt
+++ b/tests/stats_rand_gen_beta.phpt
@@ -1,0 +1,18 @@
+--TEST--
+stats_rand_gen_beta()
+--FILE--
+<?php
+var_dump(is_float(stats_rand_gen_beta(2, 3)));
+
+// error cases
+var_dump(stats_rand_gen_beta(1e-38, 1));    // a < 1e-37
+var_dump(stats_rand_gen_beta(1, 1e-38));    // b < 1e-37
+?>
+--EXPECTF--
+bool(true)
+
+Warning: stats_rand_gen_beta(): 'a' or 'b' lower than 1.0E-37. 'a' value :     1.000000E-38  'b' value :      1.000000E+0 in %s on line %d
+bool(false)
+
+Warning: stats_rand_gen_beta(): 'a' or 'b' lower than 1.0E-37. 'a' value :      1.000000E+0  'b' value :     1.000000E-38 in %s on line %d
+bool(false)

--- a/tests/stats_rand_gen_chisquare.phpt
+++ b/tests/stats_rand_gen_chisquare.phpt
@@ -1,0 +1,18 @@
+--TEST--
+stats_rand_gen_chisquare()
+--FILE--
+<?php
+var_dump(is_float(stats_rand_gen_chisquare(3)));
+
+// error cases
+var_dump(stats_rand_gen_chisquare(-0.1));   // df < 0
+var_dump(stats_rand_gen_chisquare(0));      // df == 0
+?>
+--EXPECTF--
+bool(true)
+
+Warning: stats_rand_gen_chisquare(): df <= 0.0. df :     -1.000000E-1 in %s on line %d
+bool(false)
+
+Warning: stats_rand_gen_chisquare(): df <= 0.0. df :      0.000000E+0 in %s on line %d
+bool(false)

--- a/tests/stats_rand_gen_exponential.phpt
+++ b/tests/stats_rand_gen_exponential.phpt
@@ -1,0 +1,16 @@
+--TEST--
+stats_rand_gen_exponential()
+--FILE--
+<?php
+var_dump(is_float(stats_rand_gen_exponential(2)));
+var_dump(stats_rand_gen_exponential(0));
+
+// error cases
+var_dump(stats_rand_gen_exponential(-0.1)); // av < 0
+?>
+--EXPECTF--
+bool(true)
+float(0)
+
+Warning: stats_rand_gen_exponential(): av < 0.0 in %s on line %d
+bool(false)

--- a/tests/stats_rand_gen_f.phpt
+++ b/tests/stats_rand_gen_f.phpt
@@ -1,0 +1,18 @@
+--TEST--
+stats_rand_gen_f()
+--FILE--
+<?php
+var_dump(is_float(stats_rand_gen_f(3, 2)));
+
+// error cases
+var_dump(stats_rand_gen_f(-0.1, 2));    // dfn < 0
+var_dump(stats_rand_gen_f(3, -0.1));    // dfr < 0
+?>
+--EXPECTF--
+bool(true)
+
+Warning: stats_rand_gen_f(): Degrees of freedom nonpositive. DFN value:    -1.000000E-1 DFD value:     2.000000E+0 in %s on line %d
+bool(false)
+
+Warning: stats_rand_gen_f(): Degrees of freedom nonpositive. DFN value:     3.000000E+0 DFD value:    -1.000000E-1 in %s on line %d
+bool(false)

--- a/tests/stats_rand_gen_funiform.phpt
+++ b/tests/stats_rand_gen_funiform.phpt
@@ -1,0 +1,21 @@
+--TEST--
+stats_rand_gen_funiform()
+--FILE--
+<?php
+$x = stats_rand_gen_funiform(1.5, 2.5);
+var_dump(is_float($x));
+var_dump($x > 1.5);
+var_dump($x < 2.5);
+var_dump(stats_rand_gen_funiform(1.5, 1.5));
+
+// error cases
+var_dump(stats_rand_gen_funiform(2.5, 1.5));    // low > high
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+bool(true)
+float(1.5)
+
+Warning: stats_rand_gen_funiform(): low greater than high. low :      2.500000E+0  high :      1.500000E+0 in %s on line %d
+bool(false)

--- a/tests/stats_rand_gen_gamma.phpt
+++ b/tests/stats_rand_gen_gamma.phpt
@@ -1,0 +1,26 @@
+--TEST--
+stats_rand_gen_gamma()
+--FILE--
+<?php
+var_dump(is_float(stats_rand_gen_gamma(1, 1)));
+
+// error cases
+var_dump(stats_rand_gen_gamma(-0.1, 1));    // a < 0
+var_dump(stats_rand_gen_gamma(0, 1));       // a == 0
+var_dump(stats_rand_gen_gamma(1, -.1));     // r < 0
+var_dump(stats_rand_gen_gamma(1, 0));       // r == 0
+?>
+--EXPECTF--
+bool(true)
+
+Warning: stats_rand_gen_gamma(): A or R nonpositive. A value :     -1.000000E-1 , R value :      1.000000E+0 in %s on line %d
+bool(false)
+
+Warning: stats_rand_gen_gamma(): A or R nonpositive. A value :      0.000000E+0 , R value :      1.000000E+0 in %s on line %d
+bool(false)
+
+Warning: stats_rand_gen_gamma(): A or R nonpositive. A value :      1.000000E+0 , R value :     -1.000000E-1 in %s on line %d
+bool(false)
+
+Warning: stats_rand_gen_gamma(): A or R nonpositive. A value :      1.000000E+0 , R value :      0.000000E+0 in %s on line %d
+bool(false)

--- a/tests/stats_rand_gen_ipoisson.phpt
+++ b/tests/stats_rand_gen_ipoisson.phpt
@@ -1,0 +1,16 @@
+--TEST--
+stats_rand_gen_ipoisson()
+--FILE--
+<?php
+var_dump(is_int(stats_rand_gen_ipoisson(1)));
+var_dump(stats_rand_gen_ipoisson(0));
+
+// error cases
+var_dump(stats_rand_gen_ipoisson(-0.1));    // mu < 0
+?>
+--EXPECTF--
+bool(true)
+int(0)
+
+Warning: stats_rand_gen_ipoisson(): mu < 0.0 . mu :     -1.000000E-1 in %s on line %d
+bool(false)

--- a/tests/stats_rand_gen_iuniform.phpt
+++ b/tests/stats_rand_gen_iuniform.phpt
@@ -1,0 +1,16 @@
+--TEST--
+stats_rand_gen_iuniform()
+--FILE--
+<?php
+var_dump(in_array(stats_rand_gen_iuniform(1, 3), array(1, 2, 3)));
+var_dump(stats_rand_gen_iuniform(1, 1));
+
+// error cases
+var_dump(stats_rand_gen_iuniform(2, 1));    // low > high
+?>
+--EXPECTF--
+bool(true)
+int(1)
+
+Warning: stats_rand_gen_iuniform(): low greater than high. low :                2  high                1 in %s on line %d
+bool(false)

--- a/tests/stats_rand_gen_noncenral_f.phpt
+++ b/tests/stats_rand_gen_noncenral_f.phpt
@@ -1,0 +1,26 @@
+--TEST--
+stats_rand_gen_noncenral_f()
+--FILE--
+<?php
+var_dump(is_float(stats_rand_gen_noncenral_f(2, 3, 4)));
+
+// error cases
+var_dump(stats_rand_gen_noncenral_f(0.9, 3, 4));    // dfn < 1
+var_dump(stats_rand_gen_noncenral_f(2, -0.1, 4));   // dfd < 0
+var_dump(stats_rand_gen_noncenral_f(2, 0, 4));      // dfd == 0
+var_dump(stats_rand_gen_noncenral_f(2, 3, -0.1));   // xnonc < 0
+?>
+--EXPECTF--
+bool(true)
+
+Warning: stats_rand_gen_noncenral_f(): Either (1) Numerator df < 1.0 or (2) Denominator df <= 0.0 or (3) Noncentrality parameter < 0.0. dfn:      9.000000E-1  dfd:      3.000000E+0  xnonc:      4.000000E+0 in %s on line %d
+bool(false)
+
+Warning: stats_rand_gen_noncenral_f(): Either (1) Numerator df < 1.0 or (2) Denominator df <= 0.0 or (3) Noncentrality parameter < 0.0. dfn:      2.000000E+0  dfd:     -1.000000E-1  xnonc:      4.000000E+0 in %s on line %d
+bool(false)
+
+Warning: stats_rand_gen_noncenral_f(): Either (1) Numerator df < 1.0 or (2) Denominator df <= 0.0 or (3) Noncentrality parameter < 0.0. dfn:      2.000000E+0  dfd:      0.000000E+0  xnonc:      4.000000E+0 in %s on line %d
+bool(false)
+
+Warning: stats_rand_gen_noncenral_f(): Either (1) Numerator df < 1.0 or (2) Denominator df <= 0.0 or (3) Noncentrality parameter < 0.0. dfn:      2.000000E+0  dfd:      3.000000E+0  xnonc:     -1.000000E-1 in %s on line %d
+bool(false)

--- a/tests/stats_rand_gen_noncentral_chisquare.phpt
+++ b/tests/stats_rand_gen_noncentral_chisquare.phpt
@@ -1,0 +1,18 @@
+--TEST--
+stats_rand_gen_noncentral_chisquare()
+--FILE--
+<?php
+var_dump(is_float(stats_rand_gen_noncentral_chisquare(2, 3)));
+
+// error cases
+var_dump(stats_rand_gen_noncentral_chisquare(0.9, 3));  // df < 1
+var_dump(stats_rand_gen_noncentral_chisquare(2, -0.1)); // xnonc < 0
+?>
+--EXPECTF--
+bool(true)
+
+Warning: stats_rand_gen_noncentral_chisquare(): df < 1 or xnonc < 0. df value :      9.000000E-1  xnonc value :      3.000000E+0 in %s on line %d
+bool(false)
+
+Warning: stats_rand_gen_noncentral_chisquare(): df < 1 or xnonc < 0. df value :      2.000000E+0  xnonc value :     -1.000000E-1 in %s on line %d
+bool(false)

--- a/tests/stats_rand_gen_noncentral_t.phpt
+++ b/tests/stats_rand_gen_noncentral_t.phpt
@@ -1,0 +1,14 @@
+--TEST--
+stats_rand_gen_noncentral_t()
+--FILE--
+<?php
+var_dump(is_float(stats_rand_gen_noncentral_t(2, 1)));
+
+// error cases
+var_dump(stats_rand_gen_noncentral_t(-0.1, 1)); // df < 0
+?>
+--EXPECTF--
+bool(true)
+
+Warning: stats_rand_gen_noncentral_t(): df <= 0 . df :     -1.000000E-1 in %s on line %d
+bool(false)

--- a/tests/stats_rand_gen_normal.phpt
+++ b/tests/stats_rand_gen_normal.phpt
@@ -1,0 +1,16 @@
+--TEST--
+stats_rand_gen_normal()
+--FILE--
+<?php
+var_dump(is_float(stats_rand_gen_normal(0, 1)));
+var_dump(stats_rand_gen_normal(0, 0));
+
+// error cases
+var_dump(stats_rand_gen_normal(0, -0.1)); // sd < 0
+?>
+--EXPECTF--
+bool(true)
+float(0)
+
+Warning: stats_rand_gen_normal(): sd < 0.0 . sd :     %f in %s on line %d
+bool(false)

--- a/tests/stats_rand_gen_t.phpt
+++ b/tests/stats_rand_gen_t.phpt
@@ -6,8 +6,7 @@ var_dump(is_float(stats_rand_gen_t(1)));
 
 // error cases
 var_dump(stats_rand_gen_t(-0.1));   // df < 0
-// NOT WORKED (not checked)
-// var_dump(stats_rand_gen_t(0));      // df == 0
+var_dump(stats_rand_gen_t(0));      // df == 0
 ?>
 --EXPECTF--
 bool(true)

--- a/tests/stats_rand_gen_t.phpt
+++ b/tests/stats_rand_gen_t.phpt
@@ -1,0 +1,16 @@
+--TEST--
+stats_rand_gen_t()
+--FILE--
+<?php
+var_dump(is_float(stats_rand_gen_t(1)));
+
+// error cases
+var_dump(stats_rand_gen_t(-0.1));   // df < 0
+// NOT WORKED (not checked)
+// var_dump(stats_rand_gen_t(0));      // df == 0
+?>
+--EXPECTF--
+bool(true)
+
+Warning: stats_rand_gen_t(): df <= 0 . df :     -1.000000E-1 in %s on line %d
+bool(false)

--- a/tests/stats_rand_ibinomial.phpt
+++ b/tests/stats_rand_ibinomial.phpt
@@ -1,0 +1,28 @@
+--TEST--
+stats_rand_ibinomial()
+--FILE--
+<?php
+var_dump(in_array(stats_rand_ibinomial(3, 0.7), array(0, 1, 2, 3)));
+var_dump(stats_rand_ibinomial(0, 0.7));
+var_dump(stats_rand_ibinomial(3, 0));
+var_dump(stats_rand_ibinomial(3, 1));
+
+// error cases
+var_dump(stats_rand_ibinomial(-1, 0.7));    // n < 0
+var_dump(stats_rand_ibinomial(3, -0.1));    // pp < 0
+var_dump(stats_rand_ibinomial(3, 1.1));     // pp > 1
+?>
+--EXPECTF--
+bool(true)
+int(0)
+int(0)
+int(3)
+
+Warning: stats_rand_ibinomial(): Bad values for the arguments. n : -1  pp :      7.000000E-1 in %s on line %d
+bool(false)
+
+Warning: stats_rand_ibinomial(): Bad values for the arguments. n : 3  pp :     -1.000000E-1 in %s on line %d
+bool(false)
+
+Warning: stats_rand_ibinomial(): Bad values for the arguments. n : 3  pp :      1.100000E+0 in %s on line %d
+bool(false)

--- a/tests/stats_rand_ibinomial_negative.phpt
+++ b/tests/stats_rand_ibinomial_negative.phpt
@@ -1,0 +1,23 @@
+--TEST--
+stats_rand_ibinomial_negative()
+--FILE--
+<?php
+var_dump(is_int(stats_rand_ibinomial_negative(2, 0.5)));
+
+// error cases
+var_dump(stats_rand_ibinomial_negative(-1, 0.5));   // n < 0
+var_dump(stats_rand_ibinomial_negative(1, -0.1));   // pp < 0
+var_dump(stats_rand_ibinomial_negative(1, 1.1));    // pp > 1
+
+?>
+--EXPECTF--
+bool(true)
+
+Warning: stats_rand_ibinomial_negative(): n < 0. n : -1 in %s on line %d
+bool(false)
+
+Warning: stats_rand_ibinomial_negative(): p is out of range. p :            -1E-1 in %s on line %d
+bool(false)
+
+Warning: stats_rand_ibinomial_negative(): p is out of range. p :             1E+0 in %s on line %d
+bool(false)


### PR DESCRIPTION
Test cases are added for each stats_cdf_\*, stats_dens_\*, and
stats_rand_gen_* function. Some cases are commented out at the moment
because they are failed due to implementation bugs. They should be
fixed in future.